### PR TITLE
Pin create_input to version of reference solution

### DIFF
--- a/create_input.ps1
+++ b/create_input.ps1
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# download the specific dumps used to generate the reference solution small-ref.bz2
+DUMPVERSION=20220520
+
+# download the latest data
+# DUMPVERSION=latest
+
 $ProgressPreference = 'SilentlyContinue'
 
 # 7zip gives Data Error while extracting large input file, thus using bzip2
@@ -7,13 +13,13 @@ mkdir bzip2
 wget https://github.com/philr/bzip2-windows/releases/download/v1.0.8.0/bzip2-1.0.8.0-win-x64.zip -OutFile bzip2/bzip2-1.0.8.0-win-x64.zip
 7z.exe x bzip2/bzip2-1.0.8.0-win-x64.zip -obzip2
 
-wget http://dumps.wikimedia.org/huwikisource/latest/huwikisource-latest-pages-meta-current.xml.bz2 -OutFile huwikisource-latest-pages-meta-current.xml.bz2
-bzip2/bzip2.exe -d huwikisource-latest-pages-meta-current.xml.bz2
-mv huwikisource-latest-pages-meta-current.xml data/small.data
+wget https://dumps.wikimedia.org/huwikisource/$DUMPVERSION/huwikisource-$DUMPVERSION-pages-meta-current.xml.bz2 -OutFile huwikisource-$DUMPVERSION-pages-meta-current.xml.bz2
+bzip2/bzip2.exe -d huwikisource-$DUMPVERSION-pages-meta-current.xml.bz2
+mv huwikisource-$DUMPVERSION-pages-meta-current.xml data/small.data
 
-wget http://dumps.wikimedia.org/huwiki/latest/huwiki-latest-pages-meta-current.xml.bz2 -OutFile huwiki-latest-pages-meta-current.xml.bz2
-bzip2/bzip2.exe -d huwiki-latest-pages-meta-current.xml.bz2
-mv huwiki-latest-pages-meta-current.xml data/large.data
+wget https://dumps.wikimedia.org/huwiki/$DUMPVERSION/huwiki-$DUMPVERSION-pages-meta-current.xml.bz2 -OutFile huwiki-$DUMPVERSION-pages-meta-current.xml.bz2
+bzip2/bzip2.exe -d huwiki-$DUMPVERSION-pages-meta-current.xml.bz2
+mv huwiki-$DUMPVERSION-pages-meta-current.xml data/large.data
 
 bzip2/bzip2.exe -d small-ref.bz2
 mv small-ref ref/small.out

--- a/create_input.sh
+++ b/create_input.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 
-wget http://dumps.wikimedia.org/huwikisource/latest/huwikisource-latest-pages-meta-current.xml.bz2
-bunzip2 huwikisource-latest-pages-meta-current.xml.bz2
-mv huwikisource-latest-pages-meta-current.xml data/small.data
+# Download the specific dumps used to generate the reference solution small-ref.bz2
+DUMPVERSION=20220520
 
-wget http://dumps.wikimedia.org/huwiki/latest/huwiki-latest-pages-meta-current.xml.bz2
-bunzip2 huwiki-latest-pages-meta-current.xml.bz2
-mv huwiki-latest-pages-meta-current.xml data/large.data
+# Download the latest data instead.  Note that 1st of the month full are significantly different
+# from 20th of the month partial dumps.  20220520 is a partial dump
+# https://meta.wikimedia.org/wiki/Data_dumps/Dump_frequency
+# DUMPVERSION=latest
+
+wget https://dumps.wikimedia.org/huwikisource/$DUMPVERSION/huwikisource-$DUMPVERSION-pages-meta-current.xml.bz2
+bunzip2 huwikisource-$DUMPVERSION-pages-meta-current.xml.bz2
+mv huwikisource-$DUMPVERSION-pages-meta-current.xml data/small.data
+
+wget https://dumps.wikimedia.org/huwiki/$DUMPVERSION/huwiki-$DUMPVERSION-pages-meta-current.xml.bz2
+bunzip2 huwiki-$DUMPVERSION-pages-meta-current.xml.bz2
+mv huwiki-$DUMPVERSION-pages-meta-current.xml data/large.data
 
 bunzip2 small-ref.bz2
 mv small-ref ref/small.out


### PR DESCRIPTION
Current 'latest' dumps differ from the dump version used to generate the
reference solution small-ref.bz2.  New dumps are created around the 1st
and 20th of each month.

Note - the dumps that begin on the 1st of the month are considered a full
dump while those that begin on the 20th of the month are considered a
partial dump. At least that's what the documentation says.  I haven't
noticed a difference.  https://meta.wikimedia.org/wiki/Data_dumps/Dump_frequency
The most recent partial and full dump are both around the same size (10mb
difference in size), and appear to be the same format.  Still you may want
to specify which version of the data the contest will be using, even if
that version is a dump which doesn't exist yet so precomputing the result
doesn't work.

Also set urls to https.  Wikimedia has hsts policy so it will be
negotiated anyway.

edit: spelling