### PR TITLE
Simple benchmark

### DIFF
--- a/baseline_bench.cpp
+++ b/baseline_bench.cpp
@@ -1,0 +1,17 @@
+
+#include "wordcount.hpp"
+#include <iostream>
+
+
+static std::string inputsDirPath;
+
+int main(int argc, char **argv) {
+  constexpr int mandatoryArgumentsCount = 1;
+  if (argc < 1 + mandatoryArgumentsCount) {
+    std::cerr << "Usage: lab path/to/inputs [gbench args]" << std::endl;
+    return 1;
+  }
+  inputsDirPath = argv[1];
+  wordcount(inputsDirPath);
+  return 0;
+}

--- a/cmake/helper.cmake
+++ b/cmake/helper.cmake
@@ -62,6 +62,7 @@ list(FILTER srcs EXCLUDE REGEX ".*validate.cpp$")
 # Add main targets
 add_executable(wordcount bench.cpp ${srcs} ${EXT_BENCHMARK_srcs})
 add_executable(validate_wordcount validate.cpp ${srcs} ${EXT_VALIDATE_srcs})
+add_executable(simple_wordcount simple_bench.cpp ${srcs} ${EXT_BENCHMARK_srcs})
 
 # Check optional arguments
 if(NOT DEFINED CI)

--- a/cmake/helper.cmake
+++ b/cmake/helper.cmake
@@ -63,6 +63,7 @@ list(FILTER srcs EXCLUDE REGEX ".*validate.cpp$")
 add_executable(wordcount bench.cpp ${srcs} ${EXT_BENCHMARK_srcs})
 add_executable(validate_wordcount validate.cpp ${srcs} ${EXT_VALIDATE_srcs})
 add_executable(simple_wordcount simple_bench.cpp ${srcs} ${EXT_BENCHMARK_srcs})
+add_executable(baseline_wordcount baseline_bench.cpp ${srcs} ${EXT_BENCHMARK_srcs})
 
 # Check optional arguments
 if(NOT DEFINED CI)

--- a/simple_bench.cpp
+++ b/simple_bench.cpp
@@ -1,0 +1,17 @@
+#include "wordcount.hpp"
+#include <iostream>
+
+#define SOLUTION
+
+static std::string inputsDirPath;
+
+int main(int argc, char **argv) {
+  constexpr int mandatoryArgumentsCount = 1;
+  if (argc < 1 + mandatoryArgumentsCount) {
+    std::cerr << "Usage: lab path/to/inputs [gbench args]" << std::endl;
+    return 1;
+  }
+  inputsDirPath = argv[1];
+  wordcount(inputsDirPath);
+  return 0;
+}


### PR DESCRIPTION
Added a standalone simple_wordcount executable for tools like /usr/bin/time -v, perf, hyperfine, cargo flamegraph ... that doesn't bring in Google benchmark.